### PR TITLE
excluding ifrs_report

### DIFF
--- a/travis/cfg/travis_run_pylint_exclude_100.cfg
+++ b/travis/cfg/travis_run_pylint_exclude_100.cfg
@@ -25,6 +25,7 @@ ignore=account_parent,
        smile_redis_session_store,
        gts_stock_xlsx_report_valuation,
        fedex_delivery_carrier,
+       ifrs_report,
 
 [ODOOLINT]
 manifest_deprecated_keys=


### PR DESCRIPTION
takes care of the problem caused by the odoo module "account_period_and_fiscalyear" called by the new module added by "ifrs_report" excluding "ifrs_report" from this configuration.

The problem was related to the following issue: https://amcoit.atlassian.net/browse/ODOO-1174